### PR TITLE
Modify default date selection options for analog search range

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ After cloning this template, run it this way:
 pipenv install
 export FLASK_APP=application.py
 export FLASK_DEBUG=True
-export EAPI_API_URL=http://phoebe.snap.uaf.edu:3000
+export EAPI_API_URL=https://phoebe.snap.uaf.edu:3000
 pipenv run flask run
 ```
 
@@ -25,7 +25,7 @@ Env vars which must be set:
 
  * `EAPI_API_URL` - URL for API. 
  
- Production instance of EAPI API is running at: http://phoebe.snap.uaf.edu:3000
+ Production instance of EAPI API is running at: https://phoebe.snap.uaf.edu:3000
 
 ## Deploying to AWS Elastic Beanstalk:
 

--- a/application.py
+++ b/application.py
@@ -54,7 +54,16 @@ def toggle_manual_weights_form(method):
     [Input("analog-start-month", "value"), Input("analog-start-year", "value"),],
 )
 def update_analog_start_date(month, year):
-    return datetime(month=month, year=year, day=1).strftime("%Y-%m-%d")
+    ctx = dash.callback_context
+    # If the user is loading the page for the first time,
+    # ensure that proper values are selected for the valid
+    # date ranges available.  (See the notes in gui.py about
+    # the date controls for more info)
+    if not ctx.triggered:
+        analog_start_default, analog_end_default = luts.get_default_analog_daterange()
+        return analog_start_default.strftime("%Y-%m-%d")
+    else:
+        return datetime(month=month, year=year, day=1).strftime("%Y-%m-%d")
 
 
 @app.callback(
@@ -62,7 +71,14 @@ def update_analog_start_date(month, year):
     [Input("analog-end-month", "value"), Input("analog-end-year", "value"),],
 )
 def update_analog_end_date(month, year):
-    return datetime(month=month, year=year, day=1).strftime("%Y-%m-%d")
+    ctx = dash.callback_context
+    # See above.  Update the end date for analog search range 
+    # upon first page load.
+    if not ctx.triggered:
+        analog_start_default, analog_end_default = luts.get_default_analog_daterange()
+        return analog_end_default.strftime("%Y-%m-%d")
+    else:
+        return datetime(month=month, year=year, day=1).strftime("%Y-%m-%d")
 
 
 @app.callback(

--- a/gui.py
+++ b/gui.py
@@ -14,7 +14,12 @@ import luts
 # Used in some fields & copyright date
 current_year = datetime.now().year
 
-# Compute default date ranges.
+# Compute default date ranges.  Note, these default date ranges
+# only update when the Flask code is run, so these get stale
+# when the code is running on Elastic Beanstalk.  In the app.py,
+# we force-update the fields upon page load by checking
+# if the context of the load is from a user trigger (manual change)
+# or not.
 current_date = datetime.now()
 analog_start_default, analog_end_default = luts.get_default_analog_daterange()
 forecast_end_default = current_date + relativedelta(months=2)

--- a/luts.py
+++ b/luts.py
@@ -109,26 +109,36 @@ pressure_levels = {1: "925mb", 5: "500mb", 9: "200mb"}
 
 months = {i: datetime(2020, i, 1).strftime("%B") for i in range(1, 13)}
 
+
+def get_default_analog_daterange():
+    """
+    Data are SOMETIMES available after the 10th each month.
+    So, until then, the most-current-available-month is
+    the prior month.
+
+    Known issue is that the datasets can lag by more than 3 months, 
+    causing the processing API to crash when NCL is invoked.
+
+    Not much we can do about this.
+    """
+    current_date = datetime.now()
+    if current_date.day > 10:
+        analog_start_default = current_date.replace(day=1) - relativedelta(months=4)
+        analog_end_default = current_date.replace(day=2) - relativedelta(months=2)
+    else:
+        analog_start_default = current_date.replace(day=1) - relativedelta(months=5)
+        analog_end_default = current_date.replace(day=2) - relativedelta(months=3)
+    return analog_start_default, analog_end_default
+
+
+# Set the analog end year to be the effectively-computed end year
+analog_start_default, analog_end_default = get_default_analog_daterange()
+
 analog_years = []
-for i in range(1949, datetime.now().year + 1):
+for i in range(1949, analog_end_default.year + 1):
     analog_years.append(i)
 
 # This and next year.
 forecast_years = []
 for i in range(1949, datetime.now().year + 2):
     forecast_years.append(i)
-
-def get_default_analog_daterange():
-    """
-    Data are available after the 10th each month.
-    So, until then, the most-current-available-month is
-    the prior month.
-    """
-    current_date = datetime.now()
-    if current_date.day > 10:
-        analog_start_default = current_date.replace(day=1) - relativedelta(months=3)
-        analog_end_default = current_date.replace(day=2) - relativedelta(months=1)
-    else:
-        analog_start_default = current_date.replace(day=1) - relativedelta(months=4)
-        analog_end_default = current_date.replace(day=2) - relativedelta(months=2)
-    return analog_start_default, analog_end_default


### PR DESCRIPTION
 * Make it end 3 months ago at the latest
 * Clamp year drop-down to match the end of the available default range.